### PR TITLE
ci: Test oldrel-4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
         - {os: ubuntu-latest, r: 'oldrel-1'}
         - {os: ubuntu-latest, r: 'oldrel-2'}
         - {os: ubuntu-latest, r: 'oldrel-3'}
+        - {os: ubuntu-latest, r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Tidyverse attempts to support devel, release, and oldrel 1 through 4: https://www.tidyverse.org/blog/2019/04/r-version-support/

If you're repos are public (free), I'd like to request that your testing infrastructure go back to `oldrel-4`.

Related: https://github.com/r-quantities/units/issues/402#issuecomment-2711481143